### PR TITLE
Avatar Changing Functionality

### DIFF
--- a/client/src/MainApp.vue
+++ b/client/src/MainApp.vue
@@ -9,6 +9,8 @@
       <div v-else>
         <h1>{{ board.name }}</h1>
 
+        <n-select :on-update:value="changeAvatar" :value="avatarId" :options="swappableAvatars" placeholder="Select avatar"></n-select>
+
         <h2 v-if="avatarId === null">The currently selected avatar has no controls on this board</h2>
 
         <template v-if="currentAvatar !== null">
@@ -91,6 +93,11 @@ export default {
     }
   },
   computed: {
+    swappableAvatars() {
+      return Object.entries(this.board.avatars).map(entry => {
+        return { label: entry[1].name, value: entry[0] };
+      });
+    },
     boardId() {
       if (window.location.pathname === "/") {
         return "default";
@@ -126,6 +133,9 @@ export default {
 
       const resp = await axios.get(`/api/b/${this.boardId}/full`);
       this.board = resp.data.board;
+    },
+    async changeAvatar(avatarId) {
+      await axios.get(`/api/b/${this.boardId}/change/${avatarId}`);
     },
     setupSocket() {
       if (this.boardId == null || !this.loggedIn) return;

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -1,4 +1,7 @@
 import { createApp } from 'vue';
 import MainApp from './MainApp.vue';
+import naive from "naive-ui";
 
-createApp(MainApp).mount('#app');
+createApp(MainApp)
+    .use(naive)
+    .mount('#app');

--- a/src/osc_manager.js
+++ b/src/osc_manager.js
@@ -68,6 +68,9 @@ class OscManager extends EventEmitter {
 			case "float":
 				sendValue = Number(value);
 				break;
+			case "string":
+				sendValue = String(value);
+				break;
 			default:
 				throw new Error(`Invalid OSC type ${type}`);
 		}	

--- a/src/routes/board.js
+++ b/src/routes/board.js
@@ -38,4 +38,11 @@ boardRouter.get("/current-avatar", function(req, res) {
 	}
 });
 
+boardRouter.get("/change/:avatarId", async (req, res) => {
+	const avatarId = req.params.avatarId;
+
+	const originalId = avatarManager.unhashAvatarId(avatarId);
+	await avatarManager.setAvatar(originalId);
+});
+
 module.exports = { boardRouter };

--- a/src/socket_manager.js
+++ b/src/socket_manager.js
@@ -122,14 +122,18 @@ class SocketManager {
 			this._io.to(key).emit("parameter", evt);
 		});
 
-		// evt = { id }
+		// magic fix to solve multiple clients observing avatar changes
+		// the evt object was being modified directly, which broke the subsequent checks after the first one
+		// we separate the hashedId now and it works just fine
 		this._avatarManager.on("avatar", evt => {
+			const originalId = evt.id;
+			const hashedId = this._avatarManager.hashAvatarId(originalId);
+
 			for (let socketId in this._sockets) {
-				if (this._sockets[socketId].board.hasAvatar(evt.id)) {
-					evt.id = this._avatarManager.hashAvatarId(evt.id);
-					this._sockets[socketId].socket.emit("avatar", evt);
+				if (this._sockets[socketId].board.hasAvatar(originalId)) {
+					this._sockets[socketId].socket.emit("avatar", {id: hashedId});
 				} else {
-					this._sockets[socketId].socket.emit("avatar", null); // tell this socket that we are now in an unknown avatar
+					this._sockets[socketId].socket.emit("avatar", null);
 				}
 			}
 		});

--- a/src/vrc_avatar_manager.js
+++ b/src/vrc_avatar_manager.js
@@ -114,6 +114,10 @@ class VrcAvatarManager extends EventEmitter {
 		// we're not updating the currentAvatar here. it will get updated soon after the game sends the update back to us
 	}
 
+	async setAvatar(avatarId) {
+		await this._osc.sendMessage("/avatar/change", avatarId, "string");
+	}
+
 	async registerNewParameter({ avid, paramName, inputAddress, outputAddress }) {
 		if (!(avid in this._avatars)) {
 			this._avatars[avid] = {};


### PR DESCRIPTION
Added a dropdown menu to allow users to swap the subject's avatar from the list of avatars attached to a given board. This triggers an OSC `/avatar/change` call, based on the VRC function added in [2025.1.2](https://docs.vrchat.com/docs/vrchat-202512). 

Please note: 
> You can only change to avatars in your favorites, your recents, or that you've uploaded yourself.

I also identified a bug with multiple concurrent client connections where avatar change events in [`socket_manager.js`](https://github.com/jangxx/VRC-Avatar-Remote-Server/blob/5cec90c4cb10638cb574bcf438b3dee50192963c/src/socket_manager.js#L126) would only update the first client socket, because the reused `evt` object is modified after the first loop. This should improve stability regardless of the avatar switching functionality.

I don't do PRs very often so just let me know if anything should be changed.
This tool is very useful, thank you for working on it!